### PR TITLE
Fixed typo in jac line 70 of hyperelastic demo

### DIFF
--- a/src/hyperelasticity.jl
+++ b/src/hyperelasticity.jl
@@ -67,7 +67,7 @@ jac_mat(u,du,v) =  ∫( (dE∘(∇(v),∇(u))) ⊙ (dS∘(∇(du),∇(u))) )*dΩ
 
 jac_geo(u,du,v) = ∫( ∇(v) ⊙ ( (S∘∇(u))⋅∇(du) ) )*dΩ
 
-jac(u,du,v) = jac_mat(u,v,du) + jac_geo(u,v,du)
+jac(u,du,v) = jac_mat(u,du,v) + jac_geo(u,du,v)
 
 # Construct the FEspace
 reffe = ReferenceFE(lagrangian,VectorValue{2,Float64},1)


### PR DESCRIPTION
Changed
```
jac(u,du,v) = jac_mat(u,v,du) + jac_geo(u,v,du)
```
To
```
jac(u,du,v) = jac_mat(u,du,v) + jac_geo(u,du,v)
```